### PR TITLE
Replacement of parts in files

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,28 @@ That ensures manual checks when they are regenerated, and minimizes regeneration
    Alternatively, the output files could just be removed before running the tool, or the version comments in suitable
    input files or prompt file(s) could be changed.
 
+4. **Generate parts of a file**: If you want to combine manually written and ai generated parts in one file, you can use
+   the `-wp <marker>` option to replace a part of the output file. The marker should occur in exactly two lines of the
+   already existing output file - the lines between them are replaced by the AI generated text. The first line must 
+   also contain the version commment (see below).
+
+   ```shell
+   aigenpipeline -wp generatedtable -o outputfile.md -p maketablefromjson.txt input.json
+   ```
+  
+   could e.g. replace the part between the lines `<!-- start generatedtable AIGenVersion(1.0) -->` and `<!-- end 
+   generatedtable -->` in:
+
+   ```
+   This is the hand generated part
+   <!-- start generatedtable AIGenVersion(1.0) -->
+   | Column1 | Column2 |
+   |---------|---------|
+   | value1  | value2  |
+   <!-- end generatedtable -->
+   Here can be more handwritten stuff that is untouched.
+   ```
+
 ## Caching and versioning
 
 Since generation takes time, costs a little and the results have to be manually checked, the tool takes precaution
@@ -108,40 +130,50 @@ aigenpipeline [options] [<input_files>...]
 Options:
   -h, --help               Show this help message and exit.
   --version                Show the version of the AIGenPipeline tool and exit.
-  -o, --output <file>      Specify the output file where the generated content will be written. Mandatory.
-  -p, --prompt <file>      Reads a prompt from the given file. Exactly one needs to be given.
-  -s, --sysmsg <file>      Optional: Reads a system message from the given file instead of using the default. 
-  -v, --verbose            Enable verbose output to stderr, providing more details about the process.
-  -n, --dry-run            Enable dry-run mode, where the tool will only print to stderr what it would do without 
-                           actually calling the AI or writing any files.
   -c, --check              Only check if the output needs to be regenerated based on input versions without actually 
                            generating it. The exit code is 0 if the output is up to date, 1 if it needs to be 
                            regenerated.
-  -f, --force              Force regeneration of output files, ignoring any version checks.
+  -f, --force              Force regeneration of output files, ignoring any version checks - same as -ga.
+  -ga, --gen-always        Generate the output file always, ignoring version checks.
+  -gn, --gen-notexists     Generate the output file only if it does not exist.
+  -go, --gen-older         Generate the output file if it does not exist or is older than any of the input files.
+  -gv, --gen-versioncheck  Generate the output file if the version of the input files has changed. (Default.)
+  -n, --dry-run            Enable dry-run mode, where the tool will only print to stderr what it would do without 
+                           actually calling the AI or writing any files.
+  -k <key>=<value>         Sets a key-value pair replacing ${key} in prompt files with the value. 
+  -o, --output <file>      Specify the output file where the generated content will be written. Mandatory.
+  -p, --prompt <file>      Reads a prompt from the given file.
+  -s, --sysmsg <file>      Optional: Reads a system message from the given file instead of using the default. 
+  -v, --verbose            Enable verbose output to stderr, providing more details about the process.
+  -wv, --write-version     Write the output file with a version comment. (Default.)
+  -wo, --write-noversion   Write the output file without a version comment.
+  -wp, --write-part <marker> Replace the lines between the first occurrence of the marker and the second occurrence.                           If a version marker is written, it has to be in the first of those lines and is changed there.                           It is an error if the marker does not occur exactly twice; the output file has to exist.
   -e, --explain <question> Asks the AI a question about the generated result. This needs _exactly_the_same_command_line_
                            that was given to generate the output file, and the additional --explain <question> option.
                            It recreates the conversation that lead to the output file and asks the AI for a 
                            clarification. The output file is not written, but read to recreate the conversation.
+
   -u, --url <url>          The URL of the AI server. Default is https://api.openai.com/v1/chat/completions .
                            In the case of OpenAI the API key is expected to be in the environment variable 
                            OPENAI_API_KEY, or given as -k option.
-  -k, --key <key>          The API key for the AI server. If not given, it's expected to be in the environment variable 
+  -a, --api-key <key>      The API key for the AI server. If not given, it's expected to be in the environment variable 
                            OPENAI_API_KEY, or you could use a -u option to specify a different server that doesnt need
                            an API key. Used in "Authorization: Bearer <key>" header.
   -m, --model <model>      The model to use for the AI. Default is gpt-4-turbo-preview .
+  -t <maxtokens>           The maximum number of tokens to generate.
 
 Arguments:
   [<input_files>...]       Input files to be processed. 
 
 Examples:
   Generate documentation from a prompt file:
-    aigenpipeline -p documentation_prompt.txt -o generated_documentation.md src/foo/bar.java src/foo/baz.java
+    aigenpipeline -p prompts/documentation_prompt.txt -o generated_documentation.md src/foo/bar.java src/foo/baz.java
 
   Force regenerate an interface from an OpenAPI document, ignoring version checks:
-    aigenpipeline -f -o specs/openapi.yaml -p api_interface_prompt.txt src/main/java/foo/MyInterface.java
+    aigenpipeline -f -o specs/openapi.yaml -p prompts/api_interface_prompt.txt src/main/java/foo/MyInterface.java
 
   Ask how to improve a prompt after viewing the initial generation of specs/openapi.yaml:
-    aigenpipeline -o PreviousOutput.java -p promptGenertaion.txt specs/openapi.yaml --explain "Why did you not use annotations?"  
+    aigenpipeline -o PreviousOutput.java -p prompts/promptGenertaion.txt specs/openapi.yaml --explain "Why did you not use annotations?"  
 
 Note:
   It's recommended to manually review and edit generated files. Use version control to manage and track changes over time. 

--- a/aigenpipeline-commandline/src/main/java/net/stoerr/ai/aigenpipeline/commandline/AIGenPipeline.java
+++ b/aigenpipeline-commandline/src/main/java/net/stoerr/ai/aigenpipeline/commandline/AIGenPipeline.java
@@ -15,10 +15,11 @@ import net.stoerr.ai.aigenpipeline.framework.chat.AIChatBuilder;
 import net.stoerr.ai.aigenpipeline.framework.chat.OpenAIChatBuilderImpl;
 import net.stoerr.ai.aigenpipeline.framework.task.AIGenerationTask;
 import net.stoerr.ai.aigenpipeline.framework.task.RegenerationCheckStrategy;
+import net.stoerr.ai.aigenpipeline.framework.task.WritingStrategy;
 
 public class AIGenPipeline {
 
-    protected boolean help, verbose, dryRun, check, force, version;
+    protected boolean help, verbose, dryRun, check, version;
     protected String output, explain;
     protected String url;
     protected String apiKey;
@@ -30,7 +31,8 @@ public class AIGenPipeline {
     protected File rootDir = new File(".");
     protected PrintStream logStream;
     protected Integer tokens;
-
+    protected RegenerationCheckStrategy regenerationCheckStrategy = RegenerationCheckStrategy.VERSIONMARKER;
+    protected WritingStrategy writingStrategy = WritingStrategy.WITHVERSION;
 
     public static void main(String[] args) throws IOException {
         new AIGenPipeline().run(args);
@@ -85,9 +87,8 @@ public class AIGenPipeline {
         promptFiles.stream()
                 .map(this::toFile)
                 .forEach(f -> task.addPrompt(f, keyValues));
-        if (force) {
-            task.setRegenerationCheckStrategy(RegenerationCheckStrategy.ALWAYS);
-        }
+        task.setRegenerationCheckStrategy(regenerationCheckStrategy);
+        task.setWritingStrategy(writingStrategy);
         if (check) {
             boolean hasToBeRun = task.hasToBeRun();
             if (verbose) {
@@ -123,21 +124,30 @@ public class AIGenPipeline {
                 "Options:\n" +
                 "  -h, --help               Show this help message and exit.\n" +
                 "  --version                Show the version of the AIGenPipeline tool and exit.\n" +
-                "  -o, --output <file>      Specify the output file where the generated content will be written. Mandatory.\n" +
-                "  -p, --prompt <file>      Reads a prompt from the given file.\n" +
-                "  -k <key>=<value>         Sets a key-value pair replacing ${key} in prompt files with the value. \n" +
-                "  -s, --sysmsg <file>      Optional: Reads a system message from the given file instead of using the default. \n" +
-                "  -v, --verbose            Enable verbose output to stderr, providing more details about the process.\n" +
-                "  -n, --dry-run            Enable dry-run mode, where the tool will only print to stderr what it would do without \n" +
-                "                           actually calling the AI or writing any files.\n" +
                 "  -c, --check              Only check if the output needs to be regenerated based on input versions without actually \n" +
                 "                           generating it. The exit code is 0 if the output is up to date, 1 if it needs to be \n" +
                 "                           regenerated.\n" +
-                "  -f, --force              Force regeneration of output files, ignoring any version checks.\n" +
+                "  -f, --force              Force regeneration of output files, ignoring any version checks - same as -ga.\n" +
+                // regeneration check strategy
+                "  -ga, --gen-always        Generate the output file always, ignoring version checks.\n" +
+                "  -gn, --gen-notexists     Generate the output file only if it does not exist.\n" +
+                "  -go, --gen-older         Generate the output file if it does not exist or is older than any of the input files.\n" +
+                "  -gv, --gen-versioncheck  Generate the output file if the version of the input files has changed. (Default.)\n" +
+                "  -n, --dry-run            Enable dry-run mode, where the tool will only print to stderr what it would do without \n" +
+                "                           actually calling the AI or writing any files.\n" +
+                "  -k <key>=<value>         Sets a key-value pair replacing ${key} in prompt files with the value. \n" +
+                "  -o, --output <file>      Specify the output file where the generated content will be written. Mandatory.\n" +
+                "  -p, --prompt <file>      Reads a prompt from the given file.\n" +
+                "  -s, --sysmsg <file>      Optional: Reads a system message from the given file instead of using the default. \n" +
+                "  -v, --verbose            Enable verbose output to stderr, providing more details about the process.\n" +
+                // writing strategy
+                "  -wv, --write-version     Write the output file with a version comment. (Default.)\n" +
+                "  -wo, --write-noversion   Write the output file without a version comment.\n" +
                 "  -e, --explain <question> Asks the AI a question about the generated result. This needs _exactly_the_same_command_line_\n" +
                 "                           that was given to generate the output file, and the additional --explain <question> option.\n" +
                 "                           It recreates the conversation that lead to the output file and asks the AI for a \n" +
                 "                           clarification. The output file is not written, but read to recreate the conversation.\n" +
+                "\n" +
                 "  -u, --url <url>          The URL of the AI server. Default is https://api.openai.com/v1/chat/completions .\n" +
                 "                           In the case of OpenAI the API key is expected to be in the environment variable \n" +
                 "                           OPENAI_API_KEY, or given as -k option.\n" +
@@ -207,7 +217,31 @@ public class AIGenPipeline {
                     break;
                 case "-f":
                 case "--force":
-                    force = true;
+                    regenerationCheckStrategy = RegenerationCheckStrategy.ALWAYS;
+                    break;
+                case "-ga":
+                case "--gen-always":
+                    regenerationCheckStrategy = RegenerationCheckStrategy.ALWAYS;
+                    break;
+                case "-gn":
+                case "--gen-notexists":
+                    regenerationCheckStrategy = RegenerationCheckStrategy.IF_NOT_EXISTS;
+                    break;
+                case "-go":
+                case "--gen-older":
+                    regenerationCheckStrategy = RegenerationCheckStrategy.IF_OLDER;
+                    break;
+                case "-gv":
+                case "--gen-versioncheck":
+                    regenerationCheckStrategy = RegenerationCheckStrategy.VERSIONMARKER;
+                    break;
+                case "-wv":
+                case "--write-version":
+                    writingStrategy = WritingStrategy.WITHVERSION;
+                    break;
+                case "-wo":
+                case "--write-noversion":
+                    writingStrategy = WritingStrategy.WITHOUTVERSION;
                     break;
                 case "-e":
                 case "--explain":
@@ -230,6 +264,9 @@ public class AIGenPipeline {
                     tokens = Integer.parseInt(args[++i]);
                     break;
                 default:
+                    if (args[i].startsWith("-")) {
+                        throw new IllegalArgumentException("Unknown option: " + args[i]);
+                    }
                     inputFiles.add(args[i]);
                     break;
             }

--- a/aigenpipeline-commandline/src/main/java/net/stoerr/ai/aigenpipeline/commandline/AIGenPipeline.java
+++ b/aigenpipeline-commandline/src/main/java/net/stoerr/ai/aigenpipeline/commandline/AIGenPipeline.java
@@ -14,6 +14,7 @@ import java.util.Properties;
 import net.stoerr.ai.aigenpipeline.framework.chat.AIChatBuilder;
 import net.stoerr.ai.aigenpipeline.framework.chat.OpenAIChatBuilderImpl;
 import net.stoerr.ai.aigenpipeline.framework.task.AIGenerationTask;
+import net.stoerr.ai.aigenpipeline.framework.task.RegenerationCheckStrategy;
 
 public class AIGenPipeline {
 
@@ -84,7 +85,9 @@ public class AIGenPipeline {
         promptFiles.stream()
                 .map(this::toFile)
                 .forEach(f -> task.addPrompt(f, keyValues));
-        task.force(force);
+        if (force) {
+            task.setRegenerationCheckStrategy(RegenerationCheckStrategy.ALWAYS);
+        }
         if (check) {
             boolean hasToBeRun = task.hasToBeRun();
             if (verbose) {
@@ -164,7 +167,7 @@ public class AIGenPipeline {
         System.exit(onerror ? 1 : 0);
     }
 
-    protected void parseArguments(String[] args) throws IOException {
+    protected void parseArguments(String[] args) {
         for (int i = 0; i < args.length; i++) {
             switch (args[i]) {
                 case "-h":

--- a/aigenpipeline-commandline/src/main/java/net/stoerr/ai/aigenpipeline/commandline/AIGenPipeline.java
+++ b/aigenpipeline-commandline/src/main/java/net/stoerr/ai/aigenpipeline/commandline/AIGenPipeline.java
@@ -143,6 +143,9 @@ public class AIGenPipeline {
                 // writing strategy
                 "  -wv, --write-version     Write the output file with a version comment. (Default.)\n" +
                 "  -wo, --write-noversion   Write the output file without a version comment.\n" +
+                "  -wp, --write-part <marker> Replace the lines between the first occurrence of the marker and the second occurrence." +
+                "                           If a version marker is written, it has to be in the first of those lines and is changed there." +
+                "                           It is an error if the marker does not occur exactly twice; the output file has to exist.\n" +
                 "  -e, --explain <question> Asks the AI a question about the generated result. This needs _exactly_the_same_command_line_\n" +
                 "                           that was given to generate the output file, and the additional --explain <question> option.\n" +
                 "                           It recreates the conversation that lead to the output file and asks the AI for a \n" +
@@ -217,8 +220,6 @@ public class AIGenPipeline {
                     break;
                 case "-f":
                 case "--force":
-                    regenerationCheckStrategy = RegenerationCheckStrategy.ALWAYS;
-                    break;
                 case "-ga":
                 case "--gen-always":
                     regenerationCheckStrategy = RegenerationCheckStrategy.ALWAYS;
@@ -242,6 +243,10 @@ public class AIGenPipeline {
                 case "-wo":
                 case "--write-noversion":
                     writingStrategy = WritingStrategy.WITHOUTVERSION;
+                    break;
+                case "-wp":
+                case "--write-part":
+                    writingStrategy = new WritingStrategy.WritePartStrategy(args[++i]);
                     break;
                 case "-e":
                 case "--explain":

--- a/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/AIGenerationTask.java
+++ b/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/AIGenerationTask.java
@@ -295,7 +295,7 @@ public class AIGenerationTask implements Cloneable {
             return null;
         }
         requireNonNull(rootDirectory, "Root directory must not be null");
-        String rootPath = null;
+        String rootPath;
         try {
             rootPath = rootDirectory.getAbsoluteFile().getCanonicalFile().getAbsolutePath();
             String filePath = file.getAbsoluteFile().getCanonicalFile().getAbsolutePath();
@@ -364,7 +364,7 @@ public class AIGenerationTask implements Cloneable {
             chat.systemMsg(systemMessage);
         } else {
             try (InputStream defaultprompt = AIGenerationTask.class.getResourceAsStream("/defaultsystemprompt.txt")) {
-                String defaultSysPrompt = new String(defaultprompt.readAllBytes(), StandardCharsets.UTF_8);
+                String defaultSysPrompt = new String(requireNonNull(defaultprompt).readAllBytes(), StandardCharsets.UTF_8);
                 chat.systemMsg(defaultSysPrompt);
             } catch (IOException e) {
                 throw new IllegalStateException("Error reading default system message", e);

--- a/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/AIVersionMarker.java
+++ b/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/AIVersionMarker.java
@@ -54,9 +54,21 @@ public class AIVersionMarker {
         return new AIVersionMarker(ourVersion, inputVersions);
     }
 
+    @Nullable
+    public static String replaceMarkerIn(@Nullable String content, @Nonnull String newMarker) {
+        if (content == null) {
+            return null;
+        }
+        Matcher matcher = VERSION_MARKER_PATTERN.matcher(content);
+        if (!matcher.find()) {
+            return content;
+        }
+        return matcher.replaceFirst(newMarker);
+    }
+
     /** Determine the version marker for input files / prompt files. */
     public static String determineFileVersionMarker(@Nonnull File file) {
-        String content = null;
+        String content;
         try {
             content = Files.readString(file.toPath(), StandardCharsets.UTF_8);
         } catch (IOException e) {

--- a/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/RegenerationCheckStrategy.java
+++ b/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/RegenerationCheckStrategy.java
@@ -1,0 +1,51 @@
+package net.stoerr.ai.aigenpipeline.framework.task;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A strategy to decide whether we need to regenerate an output file from input files.
+ */
+public interface RegenerationCheckStrategy {
+
+    /**
+     * Decides whether the output file needs to be regenerated.
+     *
+     * @param output the output file
+     * @param inputs the input files . Caution: a file with name "-" is a placeholder for stdin - it is not a file.
+     * @return true if the output file needs to be regenerated.
+     */
+    boolean needsRegeneration(@Nonnull File output, @Nonnull List<File> inputs);
+
+    final RegenerationCheckStrategy ALWAYS = (output, inputs) -> true;
+
+    final RegenerationCheckStrategy IF_NOT_EXISTS = (output, inputs) -> !output.exists();
+
+    /**
+     * Regenerate when output file does not exist or is older than one of the input files.
+     */
+    final RegenerationCheckStrategy IF_OLDER = (output, inputs) -> {
+        if (!output.exists()) return true;
+        long outputTime = output.lastModified();
+        for (File input : inputs) {
+            if (input.getName().equals("-")) continue;
+            if (input.lastModified() > outputTime) return true;
+        }
+        return false;
+    };
+
+    final RegenerationCheckStrategy VERSIONMARKER = (output, inputs) -> {
+        throw new UnsupportedOperationException("Not implemented yet."); // FIXME hps 24/04/27 not implemented
+    };
+
+    static final Map<String, RegenerationCheckStrategy> STRATEGIES = Map.of(
+            "a", ALWAYS,
+            "n", IF_NOT_EXISTS,
+            "o", IF_OLDER,
+            "v", VERSIONMARKER
+    );
+
+}

--- a/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/RegenerationCheckStrategy.java
+++ b/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/RegenerationCheckStrategy.java
@@ -62,12 +62,4 @@ public interface RegenerationCheckStrategy {
 
     }
 
-    Map<String, RegenerationCheckStrategy> STRATEGIES = Map.of(
-            "a", ALWAYS,
-            "n", IF_NOT_EXISTS,
-            "o", IF_OLDER,
-            "v", VERSIONMARKER
-    );
-
-
 }

--- a/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/RegenerationCheckStrategy.java
+++ b/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/RegenerationCheckStrategy.java
@@ -20,14 +20,14 @@ public interface RegenerationCheckStrategy {
      */
     boolean needsRegeneration(@Nonnull File output, @Nonnull List<File> inputs);
 
-    final RegenerationCheckStrategy ALWAYS = (output, inputs) -> true;
+    RegenerationCheckStrategy ALWAYS = (output, inputs) -> true;
 
-    final RegenerationCheckStrategy IF_NOT_EXISTS = (output, inputs) -> !output.exists();
+    RegenerationCheckStrategy IF_NOT_EXISTS = (output, inputs) -> !output.exists();
 
     /**
      * Regenerate when output file does not exist or is older than one of the input files.
      */
-    final RegenerationCheckStrategy IF_OLDER = (output, inputs) -> {
+    RegenerationCheckStrategy IF_OLDER = (output, inputs) -> {
         if (!output.exists()) return true;
         long outputTime = output.lastModified();
         for (File input : inputs) {
@@ -37,11 +37,11 @@ public interface RegenerationCheckStrategy {
         return false;
     };
 
-    final RegenerationCheckStrategy VERSIONMARKER = (output, inputs) -> {
+    RegenerationCheckStrategy VERSIONMARKER = (output, inputs) -> {
         throw new UnsupportedOperationException("Not implemented yet."); // FIXME hps 24/04/27 not implemented
     };
 
-    static final Map<String, RegenerationCheckStrategy> STRATEGIES = Map.of(
+    Map<String, RegenerationCheckStrategy> STRATEGIES = Map.of(
             "a", ALWAYS,
             "n", IF_NOT_EXISTS,
             "o", IF_OLDER,

--- a/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/RegenerationCheckStrategy.java
+++ b/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/RegenerationCheckStrategy.java
@@ -1,6 +1,8 @@
 package net.stoerr.ai.aigenpipeline.framework.task;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -14,20 +16,23 @@ public interface RegenerationCheckStrategy {
     /**
      * Decides whether the output file needs to be regenerated.
      *
-     * @param output the output file
-     * @param inputs the input files . Caution: a file with name "-" is a placeholder for stdin - it is not a file.
+     * @param output            the output file
+     * @param inputs            the input files . Caution: a file with name "-" is a placeholder for stdin - it is not a file.
+     * @param writingStrategy   the writing strategy used to write the output file.
+     * @param inputVersions     versions of all inputs
      * @return true if the output file needs to be regenerated.
      */
-    boolean needsRegeneration(@Nonnull File output, @Nonnull List<File> inputs);
+    boolean needsRegeneration(@Nonnull File output, @Nonnull List<File> inputs,
+                              @Nonnull WritingStrategy writingStrategy, @Nonnull List<String> inputVersions) throws IOException;
 
-    RegenerationCheckStrategy ALWAYS = (output, inputs) -> true;
+    RegenerationCheckStrategy ALWAYS = (output, inputs, writingStrategy, inputVersions) -> true;
 
-    RegenerationCheckStrategy IF_NOT_EXISTS = (output, inputs) -> !output.exists();
+    RegenerationCheckStrategy IF_NOT_EXISTS = (output, inputs, writingStrategy, additionalMarkers) -> !output.exists();
 
     /**
      * Regenerate when output file does not exist or is older than one of the input files.
      */
-    RegenerationCheckStrategy IF_OLDER = (output, inputs) -> {
+    RegenerationCheckStrategy IF_OLDER = (output, inputs, writingStrategy, inputVersions) -> {
         if (!output.exists()) return true;
         long outputTime = output.lastModified();
         for (File input : inputs) {
@@ -37,9 +42,25 @@ public interface RegenerationCheckStrategy {
         return false;
     };
 
-    RegenerationCheckStrategy VERSIONMARKER = (output, inputs) -> {
-        throw new UnsupportedOperationException("Not implemented yet."); // FIXME hps 24/04/27 not implemented
-    };
+    RegenerationCheckStrategy VERSIONMARKER = new VersionMarkerRegenerationCheckStrategy();
+
+    public class VersionMarkerRegenerationCheckStrategy implements RegenerationCheckStrategy {
+
+        @Override
+        public boolean needsRegeneration(@Nonnull File output, @Nonnull List<File> inputs,
+                                         @Nonnull WritingStrategy writingStrategy, @Nonnull List<String> inputVersions) throws IOException {
+            if (!output.exists()) {
+                return true;
+            }
+            AIVersionMarker outputVersionMarker = writingStrategy.getRecordedVersionMarker(output);
+            if (outputVersionMarker == null) {
+                return true;
+            }
+            List<String> oldInputVersions = outputVersionMarker.getInputVersions();
+            return !new HashSet<Object>(inputVersions).equals(new HashSet<Object>(oldInputVersions));
+        }
+
+    }
 
     Map<String, RegenerationCheckStrategy> STRATEGIES = Map.of(
             "a", ALWAYS,
@@ -47,5 +68,6 @@ public interface RegenerationCheckStrategy {
             "o", IF_OLDER,
             "v", VERSIONMARKER
     );
+
 
 }

--- a/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/WritingStrategy.java
+++ b/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/WritingStrategy.java
@@ -1,0 +1,78 @@
+package net.stoerr.ai.aigenpipeline.framework.task;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Ways to write a file and embed the version comment.
+ */
+public interface WritingStrategy {
+
+    void write(@Nonnull File output, @Nonnull String content, @Nonnull String versionComment) throws IOException;
+
+    /**
+     * Writes the raw file without the cersion comment.
+     */
+    static final WritingStrategy WITHOUTVERSION = new WritingStrategy() {
+        @Override
+        public void write(@Nonnull File output, @Nonnull String content, @Nonnull String versionComment) throws IOException {
+            Files.write(output.toPath(), content.getBytes(StandardCharsets.UTF_8));
+        }
+    };
+
+    /**
+     * Writes the file with the version comment.
+     */
+    static final WritingStrategy WITHVERSION = new WritingStrategy() {
+        @Override
+        public void write(@Nonnull File output, @Nonnull String content, @Nonnull String versionComment) throws IOException {
+            Files.write(output.toPath(), embedComment(output, content, versionComment).getBytes(StandardCharsets.UTF_8));
+        }
+
+        protected String embedComment(@Nonnull File outputFile, String content, String comment) {
+            String result;
+            String extension = outputFile.getName().substring(outputFile.getName().lastIndexOf('.') + 1);
+            switch (extension) {
+                case "java":
+                case "txt": // there is no real comment syntax for txt, but that might be obvious to a human reader
+                    result = "// " + comment + "\n\n" + content;
+                    break;
+                case "html":
+                case "htm":
+                case "xml":
+                case "jsp":
+                    result = content + "\n\n<!-- " + comment + " -->\n";
+                    break;
+                case "css":
+                case "js":
+                case "json": // json is a problem, no comment syntax. Let's see whether this makes sense.
+                    result = "/* " + comment + " */\n\n" + content;
+                    break;
+                case "md":
+                    if (content.startsWith("---\n")) {
+                        result = content.replaceFirst("---\n", "---\nversion: " + comment + "\n");
+                    } else {
+                        result = "---\nversion: " + comment + "\n---\n\n" + content;
+                    }
+                    break;
+                case "sh":
+                case "yaml":
+                    result = "# " + comment + "\n" + content;
+                    break;
+                default:
+                    result = "/* " + comment + " */\n\n" + content;
+                    break;
+            }
+            if (!result.endsWith("\n")) {
+                result += "\n";
+            }
+            return result;
+        }
+
+    };
+
+}

--- a/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/WritingStrategy.java
+++ b/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/WritingStrategy.java
@@ -148,8 +148,9 @@ public interface WritingStrategy {
             if (lines.stream().filter(line -> line.contains(marker)).count() != 2) {
                 throw new IllegalArgumentException("Marker " + marker + " is not exactly twice in " + output);
             }
-            int firstMarker = lines.indexOf(marker);
-            int secondMarker = lines.subList(firstMarker + 1, lines.size()).indexOf(marker) + firstMarker + 1;
+            int firstMarker = lines.indexOf(lines.stream().filter(line -> line.contains(marker)).findFirst().get());
+            List<String> rest = lines.subList(firstMarker + 1, lines.size());
+            int secondMarker = rest.indexOf(rest.stream().filter(line -> line.contains(marker)).findFirst().get()) + firstMarker + 1;
             if (content.contains(marker)) {
                 throw new IllegalArgumentException("Content contains marker " + marker + ". That would lead to trouble next time.");
             }

--- a/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/WritingStrategy.java
+++ b/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/WritingStrategy.java
@@ -17,7 +17,7 @@ public interface WritingStrategy {
     /**
      * Writes the raw file without the cersion comment.
      */
-    static final WritingStrategy WITHOUTVERSION = new WritingStrategy() {
+    WritingStrategy WITHOUTVERSION = new WritingStrategy() {
         @Override
         public void write(@Nonnull File output, @Nonnull String content, @Nonnull String versionComment) throws IOException {
             Files.write(output.toPath(), content.getBytes(StandardCharsets.UTF_8));
@@ -27,7 +27,7 @@ public interface WritingStrategy {
     /**
      * Writes the file with the version comment.
      */
-    static final WritingStrategy WITHVERSION = new WritingStrategy() {
+    WritingStrategy WITHVERSION = new WritingStrategy() {
         @Override
         public void write(@Nonnull File output, @Nonnull String content, @Nonnull String versionComment) throws IOException {
             Files.write(output.toPath(), embedComment(output, content, versionComment).getBytes(StandardCharsets.UTF_8));

--- a/aigenpipeline-framework/src/test/java/net/stoerr/ai/aigenpipeline/framework/task/AIGenerationTaskTest.java
+++ b/aigenpipeline-framework/src/test/java/net/stoerr/ai/aigenpipeline/framework/task/AIGenerationTaskTest.java
@@ -114,4 +114,22 @@ public class AIGenerationTaskTest {
         assertEquals(task.toString(), copy.toString());
     }
 
+    @Test
+    public void testReplacePart() throws IOException {
+        AIGenerationTask task = new AIGenerationTask();
+
+        task.addPrompt(inputDir.resolve("prompt.txt").toFile());
+        task.addInputFile(inputDir.resolve("input.txt").toFile());
+        task.addInputFile(inputDir.resolve("inputWithVersion.txt").toFile());
+        Path outFile = tempDir.resolve("outputWithReplacement.txt");
+        Files.copy(inputDir.resolve("outputWithReplacement.txt"), outFile);
+        task.setOutputFile(outFile.toFile());
+        task.setWritingStrategy(new WritingStrategy.WritePartStrategy("thereplacedpart"));
+
+
+        Assert.assertTrue(task.hasToBeRun());
+        task.execute(MockAIChatBuilder::new, new File("."));
+        checkOutputExistsAndIsAsExpected(outFile);
+    }
+
 }

--- a/aigenpipeline-framework/src/test/java/net/stoerr/ai/aigenpipeline/framework/task/AIVersionMarkerTest.java
+++ b/aigenpipeline-framework/src/test/java/net/stoerr/ai/aigenpipeline/framework/task/AIVersionMarkerTest.java
@@ -38,4 +38,30 @@ public class AIVersionMarkerTest {
         Assert.assertEquals(null, marker.getOurVersion());
         Assert.assertTrue(marker.getInputVersions().isEmpty());
     }
+
+
+    @Test
+    public void replacesMarkerInContentWithSingleMarker() {
+        String content = "Some text AIGenVersion(1.0, file1@1.1, file2@1.2) more text";
+        String newMarker = "AIGenVersion(2.0, file3@2.1, file4@2.2)";
+        String expected = "Some text AIGenVersion(2.0, file3@2.1, file4@2.2) more text";
+        String result = AIVersionMarker.replaceMarkerIn(content, newMarker);
+        Assert.assertEquals(expected, result);
+    }
+
+    @Test
+    public void doesNotReplaceMarkerInContentWithoutMarker() {
+        String content = "Some text without marker more text";
+        String newMarker = "AIGenVersion(2.0, file3@2.1, file4@2.2)";
+        String result = AIVersionMarker.replaceMarkerIn(content, newMarker);
+        Assert.assertEquals(content, result);
+    }
+
+    @Test
+    public void returnsNullWhenContentIsNull() {
+        String newMarker = "AIGenVersion(2.0, file3@2.1, file4@2.2)";
+        String result = AIVersionMarker.replaceMarkerIn(null, newMarker);
+        Assert.assertNull(result);
+    }
+
 }

--- a/aigenpipeline-framework/src/test/resources/aigenpipeline-test/expected/outputWithReplacement.txt
+++ b/aigenpipeline-framework/src/test/resources/aigenpipeline-test/expected/outputWithReplacement.txt
@@ -1,0 +1,38 @@
+this should be left alone at the beginning.
+yes yes
+<!-- start of thereplacedpart AIGenVersion(6881255a, prompt.txt-45366fcf, input.txt-7e10dd2a, inputWithVersion.txt-1.1) -->
+Response to:
+{
+  "model": "gpt-4-turbo-preview",
+  "messages": [
+    {
+      "role": "system",
+      "content": "You are an expert programming assistant who follows the users instructions exactly and to the letter.\nYou observe the rules of clean code, KISS, YAGNI, and DRY and love good documentation and well documented code.\nDo never ever give any introductory or concluding text, just the requested output, except if explicitly asked for.\n\nIMPORTANT: If something in the instructions is unclear, there is information missing, you have any questions\nor after printing the response you notice that something was wrong, then append to the file a paragraph starting with\n`EMCIF(AI) ` and a description of that problem.\n"
+    },
+    {
+      "role": "user",
+      "content": "Retrieve the content of the input file src/test/resources/aigenpipeline-test/input.txt"
+    },
+    {
+      "role": "assistant",
+      "content": "This is a test input file for AIGenerationTask."
+    },
+    {
+      "role": "user",
+      "content": "Retrieve the content of the input file src/test/resources/aigenpipeline-test/inputWithVersion.txt"
+    },
+    {
+      "role": "assistant",
+      "content": "--\nversion: \n--\nThis is a test input file for AIGenerationTask.\n"
+    },
+    {
+      "role": "user",
+      "content": "This is a test prompt for AIGenerationTask."
+    }
+  ],
+  "temperature": 0.0,
+  "max_tokens": 2048
+}
+<!-- end of thereplacedpart AIGenVersion() -->
+this should be left alone at the end.
+yes

--- a/aigenpipeline-framework/src/test/resources/aigenpipeline-test/outputWithReplacement.txt
+++ b/aigenpipeline-framework/src/test/resources/aigenpipeline-test/outputWithReplacement.txt
@@ -1,0 +1,7 @@
+this should be left alone at the beginning.
+yes yes
+<!-- start of thereplacedpart AIGenVersion(1) -->
+this should be overwritten
+<!-- end of thereplacedpart AIGenVersion() -->
+this should be left alone at the end.
+yes

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -75,6 +75,28 @@ That ensures manual checks when they are regenerated, and minimizes regeneration
    Alternatively, the output files could just be removed before running the tool, or the version comments in suitable
    input files or prompt file(s) could be changed.
 
+4. **Generate parts of a file**: If you want to combine manually written and ai generated parts in one file, you can use
+   the `-wp <marker>` option to replace a part of the output file. The marker should occur in exactly two lines of the
+   already existing output file - the lines between them are replaced by the AI generated text. The first line must 
+   also contain the version commment (see below).
+
+   ```shell
+   aigenpipeline -wp generatedtable -o outputfile.md -p maketablefromjson.txt input.json
+   ```
+  
+   could e.g. replace the part between the lines `<!-- start generatedtable AIGenVersion(1.0) -->` and `<!-- end 
+   generatedtable -->` in:
+
+   ```
+   This is the hand generated part
+   <!-- start generatedtable AIGenVersion(1.0) -->
+   | Column1 | Column2 |
+   |---------|---------|
+   | value1  | value2  |
+   <!-- end generatedtable -->
+   Here can be more handwritten stuff that is untouched.
+   ```
+
 ## Caching and versioning
 
 Since generation takes time, costs a little and the results have to be manually checked, the tool takes precaution
@@ -127,40 +149,50 @@ aigenpipeline [options] [<input_files>...]
 Options:
   -h, --help               Show this help message and exit.
   --version                Show the version of the AIGenPipeline tool and exit.
-  -o, --output <file>      Specify the output file where the generated content will be written. Mandatory.
-  -p, --prompt <file>      Reads a prompt from the given file. Exactly one needs to be given.
-  -s, --sysmsg <file>      Optional: Reads a system message from the given file instead of using the default. 
-  -v, --verbose            Enable verbose output to stderr, providing more details about the process.
-  -n, --dry-run            Enable dry-run mode, where the tool will only print to stderr what it would do without 
-                           actually calling the AI or writing any files.
   -c, --check              Only check if the output needs to be regenerated based on input versions without actually 
                            generating it. The exit code is 0 if the output is up to date, 1 if it needs to be 
                            regenerated.
-  -f, --force              Force regeneration of output files, ignoring any version checks.
+  -f, --force              Force regeneration of output files, ignoring any version checks - same as -ga.
+  -ga, --gen-always        Generate the output file always, ignoring version checks.
+  -gn, --gen-notexists     Generate the output file only if it does not exist.
+  -go, --gen-older         Generate the output file if it does not exist or is older than any of the input files.
+  -gv, --gen-versioncheck  Generate the output file if the version of the input files has changed. (Default.)
+  -n, --dry-run            Enable dry-run mode, where the tool will only print to stderr what it would do without 
+                           actually calling the AI or writing any files.
+  -k <key>=<value>         Sets a key-value pair replacing ${key} in prompt files with the value. 
+  -o, --output <file>      Specify the output file where the generated content will be written. Mandatory.
+  -p, --prompt <file>      Reads a prompt from the given file.
+  -s, --sysmsg <file>      Optional: Reads a system message from the given file instead of using the default. 
+  -v, --verbose            Enable verbose output to stderr, providing more details about the process.
+  -wv, --write-version     Write the output file with a version comment. (Default.)
+  -wo, --write-noversion   Write the output file without a version comment.
+  -wp, --write-part <marker> Replace the lines between the first occurrence of the marker and the second occurrence.                           If a version marker is written, it has to be in the first of those lines and is changed there.                           It is an error if the marker does not occur exactly twice; the output file has to exist.
   -e, --explain <question> Asks the AI a question about the generated result. This needs _exactly_the_same_command_line_
                            that was given to generate the output file, and the additional --explain <question> option.
                            It recreates the conversation that lead to the output file and asks the AI for a 
                            clarification. The output file is not written, but read to recreate the conversation.
+
   -u, --url <url>          The URL of the AI server. Default is https://api.openai.com/v1/chat/completions .
                            In the case of OpenAI the API key is expected to be in the environment variable 
                            OPENAI_API_KEY, or given as -k option.
-  -k, --key <key>          The API key for the AI server. If not given, it's expected to be in the environment variable 
+  -a, --api-key <key>      The API key for the AI server. If not given, it's expected to be in the environment variable 
                            OPENAI_API_KEY, or you could use a -u option to specify a different server that doesnt need
                            an API key. Used in "Authorization: Bearer <key>" header.
   -m, --model <model>      The model to use for the AI. Default is gpt-4-turbo-preview .
+  -t <maxtokens>           The maximum number of tokens to generate.
 
 Arguments:
   [<input_files>...]       Input files to be processed. 
 
 Examples:
   Generate documentation from a prompt file:
-    aigenpipeline -p documentation_prompt.txt -o generated_documentation.md src/foo/bar.java src/foo/baz.java
+    aigenpipeline -p prompts/documentation_prompt.txt -o generated_documentation.md src/foo/bar.java src/foo/baz.java
 
   Force regenerate an interface from an OpenAPI document, ignoring version checks:
-    aigenpipeline -f -o specs/openapi.yaml -p api_interface_prompt.txt src/main/java/foo/MyInterface.java
+    aigenpipeline -f -o specs/openapi.yaml -p prompts/api_interface_prompt.txt src/main/java/foo/MyInterface.java
 
   Ask how to improve a prompt after viewing the initial generation of specs/openapi.yaml:
-    aigenpipeline -o PreviousOutput.java -p promptGenertaion.txt specs/openapi.yaml --explain "Why did you not use annotations?"  
+    aigenpipeline -o PreviousOutput.java -p prompts/promptGenertaion.txt specs/openapi.yaml --explain "Why did you not use annotations?"  
 
 Note:
   It's recommended to manually review and edit generated files. Use version control to manage and track changes over time. 


### PR DESCRIPTION
This adds a feature to replace only parts in files with AI generated text - for instance if you want to have manually witten and automatically generated text in one file, or combine generated text from several calls in one file.

You can use the `-wp <marker>` option to replace a part of the output file. The marker should occur in exactly two lines of the already existing output file - the lines between them are replaced by the AI generated text. The first line must also contain the version commment (see below).

 ```shell
 aigenpipeline -wp generatedtable -o outputfile.md -p maketablefromjson.txt input.json
 ```  
 could e.g. replace the part between the lines `<!-- start generatedtable AIGenVersion(1.0) -->` and `<!-- end 
 generatedtable -->` in:

 ```
 This is the hand generated part
 <!-- start generatedtable AIGenVersion(1.0) -->
 | Column1 | Column2 |
 |---------|---------|
 | value1  | value2  |
 <!-- end generatedtable -->
 Here can be more handwritten stuff that is untouched.
 ```
