### PR TITLE
instruct to minimize changes if output file is given as input file

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ That ensures manual checks when they are regenerated, and minimizes regeneration
    aigenpipeline -p test_prompt.txt -i generated_interface.java -o generated_test.java
    ```
 
+   By the way: if you want to change an existing output file, you can give it as additional input file to the AI. 
+   It will be instructed to check and update the file according to the new input files, minimizing the changes.
+
 2. **Explanation / Query**: After generating an output, if there are questions or the need for clarification on how to
    improve it:
 

--- a/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/chat/OpenAIChatBuilderImpl.java
+++ b/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/chat/OpenAIChatBuilderImpl.java
@@ -153,7 +153,7 @@ public class OpenAIChatBuilderImpl implements AIChatBuilder {
         if (organizationId != null) {
             builder.header("OpenAI-Organization", organizationId);
         }
-        builder.timeout(Duration.ofSeconds(60));
+        builder.timeout(Duration.ofSeconds(120));
         HttpRequest request = builder.build();
         try {
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());

--- a/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/AIGenerationTask.java
+++ b/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/AIGenerationTask.java
@@ -306,7 +306,7 @@ public class AIGenerationTask implements Cloneable {
 
     @Nonnull
     protected AIChatBuilder makeChatBuilder(@Nonnull Supplier<AIChatBuilder> chatBuilderFactory, @Nonnull File rootDirectory, String outputRelPath) {
-        requireNonNull(outputFile, "No writeable output file given! " + outputFile);
+        requireNonNull(outputFile, "Output file not writeable: " + outputFile);
         if (null != outputFile.getParentFile() && !outputFile.getParentFile().isDirectory()) {
             outputFile.getParentFile().mkdirs();
         }
@@ -332,7 +332,13 @@ public class AIGenerationTask implements Cloneable {
         }
         inputFiles.forEach(file -> {
             // "Put it into the AI's mouth" pattern https://www.stoerr.net/blog/aimouth
-            chat.userMsg("Retrieve the content of the input file " + relativePath(file, rootDirectory));
+            String path = relativePath(file, rootDirectory);
+            String usermsg = !file.getAbsolutePath().equals(outputFile.getAbsolutePath()) ?
+                            "Retrieve the content of the input file " + path :
+                            "Retrieve the current content of the output file " + path +
+                                    " Later you will take this file as basis for the output, check it and possibly modify it, " +
+                                    "but minimize changes.";
+            chat.userMsg(usermsg);
             String fileContent = getFileContent(file);
             if (fileContent == null) {
                 throw new IllegalArgumentException("Could not read input file " + file);

--- a/examples/requesttocode/createcode-changed.prompt
+++ b/examples/requesttocode/createcode-changed.prompt
@@ -1,0 +1,15 @@
+You are a professional Java developer who observes best practices and creates well documented code.
+
+Create an implementation net.stoerr.ai.aigenpipeline.examples.requesttocodeChatGPTPromptExecutorImpl of the interface
+that sends the JSON payload given in the example request to
+https://api.openai.com/v1/chat/completions
+with the headers
+Content-Type: application/json
+Authorization: Bearer $OPENAI_API_KEY
+OpenAI-Organization: $OPENAI_ORGID
+where $OPENAI_API_KEY and $OPENAI_ORGID are keys to be read from the corresponding environment variables.
+Use the java.net.http.HttpClient and encode the JSON payload with Gson.
+Create inner classes for the JSON payload and response. The model used should be a constant in the class.
+It should parse the response and return the content element of the response as a string, ignoring other elements except finish_reason.
+For testing create a main method that takes the system message and the prompt as arguments.
+If the finish_reason is not stop , throw an exception with the message from the model.

--- a/examples/requesttocode/generate.sh
+++ b/examples/requesttocode/generate.sh
@@ -8,4 +8,9 @@ if [ -f "$OUTFILE" ]; then
   EXISTINGOUTFILE="$OUTFILE"
 fi
 set -x -e
-$CMD -p codeRules.prompt -p createcode.prompt -o ChatGPTPromptExecutorImpl.java $EXISTINGOUTFILE ChatGPTPromptExecutor.java request.json response.json
+
+# Minimize changes if requirements are changed
+$CMD -v -p codeRules.prompt -p createcode.prompt -o ChatGPTPromptExecutorImpl.java $EXISTINGOUTFILE ChatGPTPromptExecutor.java request.json response.json
+
+# Or just regenerate
+# $CMD -p codeRules.prompt -p createcode.prompt -o ChatGPTPromptExecutorImpl.java ChatGPTPromptExecutor.java request.json response.json

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -56,6 +56,9 @@ That ensures manual checks when they are regenerated, and minimizes regeneration
    aigenpipeline -p test_prompt.txt -i generated_interface.java -o generated_test.java
    ```
 
+   By the way: if you want to change an existing output file, you can give it as additional input file to the AI. 
+   It will be instructed to check and update the file according to the new input files, minimizing the changes.
+
 2. **Explanation / Query**: After generating an output, if there are questions or the need for clarification on how to
    improve it:
 


### PR DESCRIPTION
If you add the output file as additional input file, the tool can be used to update a file, minimizing changes to fulfill the instructions. One instance is the https://github.com/stoerr/AIGenPipeline/tree/develop/examples/requesttocode example:

`aigenpipeline -p codeRules.prompt -p createcode.prompt -o ChatGPTPromptExecutorImpl.java $EXISTINGOUTFILE ChatGPTPromptExecutor.java request.json response.json`

This PR improves the instructions given to the LLM in that case, specifically to:

        "Retrieve the current content of the output file " + path +
        " Later you will take this file as basis for the output, check it and possibly modify it, " +
        "but minimize changes.";
