### PR TITLE
Print a Mermaid dependency graph for -os (output scan) with -dd

### DIFF
--- a/aigenpipeline-commandline/src/main/java/net/stoerr/ai/aigenpipeline/commandline/AIDepDiagram.java
+++ b/aigenpipeline-commandline/src/main/java/net/stoerr/ai/aigenpipeline/commandline/AIDepDiagram.java
@@ -1,0 +1,61 @@
+package net.stoerr.ai.aigenpipeline.commandline;
+
+import java.io.File;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import net.stoerr.ai.aigenpipeline.framework.task.AIInOut;
+
+public class AIDepDiagram {
+
+    protected final List<AIGenPipeline> pipelines;
+    protected final File rootDir;
+
+    protected int nextId = 1;
+    protected Map<String, String> pathToId = new HashMap<>();
+
+    public AIDepDiagram(List<AIGenPipeline> pipelines, File rootDir) {
+        this.pipelines = pipelines;
+        this.rootDir = rootDir;
+    }
+
+    /**
+     * Prints a dependency diagram of the pipelines to the given output stream.
+     */
+    public void printDepDiagram(PrintStream out) {
+        out.println("graph TD");
+        for (AIGenPipeline pipeline : pipelines) {
+            String outId = idForInOut(pipeline.taskOutput);
+            String outLabel = labelForInOut(pipeline.taskOutput);
+            for (AIInOut input : pipeline.inputFiles) {
+                String inId = idForInOut(input);
+                String inLabel = labelForInOut(input);
+                out.println("    " + inId + "[\"" + inLabel + "\"] --> " + outId + "[\"" + outLabel + "\"]");
+            }
+            for (AIInOut prompt : pipeline.promptFiles) {
+                String inId = idForInOut(prompt);
+                String inLabel = labelForInOut(prompt);
+                out.println("    " + inId + "([\"" + inLabel + "\"]) --> " + outId + "[\"" + outLabel + "\"]");
+            }
+        }
+    }
+
+    protected String labelForInOut(AIInOut inOut) {
+        Path other = inOut.getFile().getAbsoluteFile().toPath();
+        return rootDir.getAbsoluteFile().toPath().relativize(other).toString();
+    }
+
+    protected String idForInOut(AIInOut inout) {
+        String path = inout.getFile().getAbsolutePath();
+        String id = pathToId.get(path);
+        if (null == id) {
+            id = "F" + String.valueOf(1000 + nextId++).substring(1);
+            pathToId.put(path, id);
+        }
+        return id;
+    }
+
+}

--- a/aigenpipeline-commandline/src/main/java/net/stoerr/ai/aigenpipeline/commandline/AIGenPipeline.java
+++ b/aigenpipeline-commandline/src/main/java/net/stoerr/ai/aigenpipeline/commandline/AIGenPipeline.java
@@ -197,8 +197,6 @@ public class AIGenPipeline {
         if (explain != null) {
             String explanation = task.explain(this::makeChatBuilder, rootDir, explain);
             OUT.println(explanation);
-        } else {
-            task.execute(this::makeChatBuilder, rootDir);
         }
     }
 
@@ -207,7 +205,8 @@ public class AIGenPipeline {
             new AIDepDiagram(Arrays.asList(this), rootDir).printDepDiagram(logStream);
             return;
         }
-        if (explain == null && !printdependencydiagram) {
+        if (explain == null) {
+            if (verbose) logStream.println("Executing task for " + taskOutput.getFile());
             task.execute(this::makeChatBuilder, rootDir);
         }
     }
@@ -254,7 +253,7 @@ public class AIGenPipeline {
         if (printdependencydiagram) {
             new AIDepDiagram(subPipelines, rootDir).printDepDiagram(logStream);
         } else {
-            subPipelines.forEach(AIGenPipeline::executeTask);
+            new AIDepDiagram(subPipelines, rootDir).sortedPipelines().forEach(AIGenPipeline::executeTask);
         }
     }
 

--- a/aigenpipeline-commandline/src/main/java/net/stoerr/ai/aigenpipeline/commandline/AIGenPipeline.java
+++ b/aigenpipeline-commandline/src/main/java/net/stoerr/ai/aigenpipeline/commandline/AIGenPipeline.java
@@ -488,7 +488,7 @@ public class AIGenPipeline {
     }
 
     protected void printHelp(boolean onerror) {
-        try (InputStream usageFile = getClass().getResourceAsStream("aigencmdline/usage.txt");
+        try (InputStream usageFile = getClass().getResourceAsStream("/aigencmdline/usage.txt");
              InputStreamReader reader = new InputStreamReader(
                      requireNonNull(usageFile), StandardCharsets.UTF_8)) {
             Writer writer = new StringWriter();

--- a/aigenpipeline-commandline/src/main/java/net/stoerr/ai/aigenpipeline/commandline/TopoSort.java
+++ b/aigenpipeline-commandline/src/main/java/net/stoerr/ai/aigenpipeline/commandline/TopoSort.java
@@ -1,0 +1,81 @@
+package net.stoerr.ai.aigenpipeline.commandline;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class TopoSort<T> {
+
+    private List<Edge<T>> edges = new ArrayList<>();
+
+    protected static class Edge<T> {
+        public final T from;
+        public final T to;
+
+        public Edge(T from, T to) {
+            this.to = to;
+            this.from = from;
+        }
+    }
+
+    public void addEdge(T from, T to) {
+        edges.add(new Edge<>(from, to));
+    }
+
+    /**
+     * Calculates topologically sorted list of nodes.
+     * If a cycle is detected, an IllegalArgumentException is thrown.
+     *
+     * @return sorted list of nodes - if there is an edge from node A to node B, then A will appear before B in the list
+     */
+    public List<T> sort() throws TopoSortCycleException {
+        List<T> result = new ArrayList<>();
+        Set<T> visited = new HashSet<>();
+        Set<T> visiting = new HashSet<>();
+        for (Edge<T> edge : edges) {
+            if (!visited.contains(edge.to)) {
+                visit(edge.to, visited, visiting, result);
+            }
+        }
+        return result;
+    }
+
+    protected void visit(T node, Set<T> visited, Set<T> visiting, List<T> result) throws TopoSortCycleException {
+        if (visiting.contains(node)) {
+            throw new TopoSortCycleException(node);
+        }
+        if (!visited.contains(node)) {
+            visiting.add(node);
+            for (Edge<T> edge : edges) {
+                if (edge.to.equals(node)) {
+                    visit(edge.from, visited, visiting, result);
+                }
+            }
+            visiting.remove(node);
+            visited.add(node);
+            result.add(node);
+        }
+    }
+
+    /**
+     * Is thrown to notify that there is a cycle regarding the given node.
+     */
+    public static class TopoSortCycleException extends Exception {
+        protected Object node;
+
+        public TopoSortCycleException(Object node) {
+            this.node = node;
+        }
+
+        /**
+         * One node involved into a cycle.
+         */
+        public Object getNode() {
+            return node;
+        }
+
+
+    }
+
+}

--- a/aigenpipeline-commandline/src/main/resources/aigencmdline/usage.txt
+++ b/aigenpipeline-commandline/src/main/resources/aigencmdline/usage.txt
@@ -22,6 +22,7 @@ Options:
     -k <key>=<value>         Sets a key-value pair replacing ${key} in prompt files with the value. 
     -os, --outputscan <pattern>  Searches for files matching the ant-like pattern and scans them for AIGenPromptStart markers.
                              The infile prompts in these files are processed.
+    -dd, --dependencydiagram Print a dependency diagram (Mermaid graph) of the scanned files and exit.
 
   AI Generation control:
     -f, --force              Force regeneration of output files, ignoring any version checks - same as -ga.

--- a/aigenpipeline-commandline/src/test/java/net/stoerr/ai/aigenpipeline/commandline/TopoSortTest.java
+++ b/aigenpipeline-commandline/src/test/java/net/stoerr/ai/aigenpipeline/commandline/TopoSortTest.java
@@ -1,0 +1,46 @@
+package net.stoerr.ai.aigenpipeline.commandline;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class TopoSortTest {
+
+    private TopoSort<Integer> topoSort;
+
+    @Before
+    public void setUp() {
+        topoSort = new TopoSort<>();
+    }
+
+    @Test
+    public void testSort() throws TopoSort.TopoSortCycleException {
+        topoSort.addEdge(2, 3);
+        topoSort.addEdge(1, 2);
+        topoSort.addEdge(3, 4);
+        List<Integer> sorted = topoSort.sort();
+        assertEquals(Arrays.asList(1, 2, 3, 4), sorted);
+    }
+
+    @Test(expected = TopoSort.TopoSortCycleException.class)
+    public void testSortWithCycle() throws TopoSort.TopoSortCycleException {
+        topoSort.addEdge(1, 2);
+        topoSort.addEdge(2, 3);
+        topoSort.addEdge(3, 1);
+        topoSort.sort();
+    }
+
+    @Test
+    public void testSortWithMultipleEdges() throws TopoSort.TopoSortCycleException {
+        topoSort.addEdge(2, 4);
+        topoSort.addEdge(1, 2);
+        topoSort.addEdge(1, 3);
+        topoSort.addEdge(3, 4);
+        List<Integer> sorted = topoSort.sort();
+        assertEquals(Arrays.asList(1, 2, 3, 4), sorted);
+    }
+}

--- a/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/chat/CopyPseudoAIChatBuilderImpl.java
+++ b/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/chat/CopyPseudoAIChatBuilderImpl.java
@@ -1,5 +1,7 @@
 package net.stoerr.ai.aigenpipeline.framework.chat;
 
+import static net.stoerr.ai.aigenpipeline.framework.task.AIGenerationTask.unclutter;
+
 /**
  * A pseudo AI chat model that just copies the input to the output.
  */
@@ -63,7 +65,7 @@ public class CopyPseudoAIChatBuilderImpl implements AIChatBuilder {
     @Override
     public AIChatBuilder assistantMsg(String text) {
         if (text != null) {
-            allInputs.append(text);
+            allInputs.append(unclutter(text));
         }
         return this;
     }

--- a/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/chat/OpenAIChatBuilderImpl.java
+++ b/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/chat/OpenAIChatBuilderImpl.java
@@ -1,5 +1,7 @@
 package net.stoerr.ai.aigenpipeline.framework.chat;
 
+import static net.stoerr.ai.aigenpipeline.framework.task.AIGenerationTask.FIXME;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -143,7 +145,7 @@ public class OpenAIChatBuilderImpl implements AIChatBuilder {
     @Override
     public String execute() {
         if (MODEL_OPENAIJSON.equals(model)) {
-            return toJson();
+            return toJson().replaceAll(Pattern.quote(FIXME), "FIXME ");
         }
         String key = determineApiKey();
         HttpClient client = HttpClient.newBuilder()

--- a/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/AIGenerationTask.java
+++ b/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/AIGenerationTask.java
@@ -260,7 +260,7 @@ public class AIGenerationTask implements Cloneable {
     }
 
     /* Remove some clutter that is not relevant and might even confuse the AI */
-    protected static String unclutter(String content) {
+    public static String unclutter(String content) {
         if (content == null) {
             return null;
         }

--- a/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/AIGenerationTask.java
+++ b/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/AIGenerationTask.java
@@ -63,6 +63,19 @@ public class AIGenerationTask implements Cloneable {
     protected static final Pattern PATTERN_LICENCE =
             Pattern.compile("\\A<!--(?s).*?Copyright.*?Adobe.*?Licensed under.*?-->");
 
+    /**
+     * A pattern matching infile prompts like this:
+     * <pre>
+     * <%-- AIGenPromptStart(tablefromdatacopied)
+     * Make a markdown table from the data, with columns "Name" and "Profession".
+     * AIGenCommand(tablefromdatacopied)
+     * -f -m copy tablefromdata.md
+     * AIGenPromptEnd(tablefromdatacopied) --%>
+     * </pre>
+     * This matches a line containing AIGenPromptStart with an id until the corresponding AIGenPromptEnd.
+     */
+    protected static final Pattern PATTERN_INFILEPROMPT = Pattern.compile(
+            ".*AIGenPromptStart\\(([^)]*)\\)((?s).*?)AIGenPromptEnd\\(\\1\\).*\n?");
 
     protected List<AIInOut> inputFiles = new ArrayList<>();
     protected AIInOut output;
@@ -259,7 +272,7 @@ public class AIGenerationTask implements Cloneable {
         }
     }
 
-    /* Remove some clutter that is not relevant and might even confuse the AI */
+    /* Remove some clutter that is not relevant and might even confuse the AI. */
     public static String unclutter(String content) {
         if (content == null) {
             return null;
@@ -269,6 +282,10 @@ public class AIGenerationTask implements Cloneable {
             content = matcher.replaceFirst("");
         }
         matcher = AIVersionMarker.VERSION_MARKER_PATTERN.matcher(content);
+        if (matcher.find()) {
+            content = matcher.replaceFirst("");
+        }
+        matcher = PATTERN_INFILEPROMPT.matcher(content);
         if (matcher.find()) {
             content = matcher.replaceFirst("");
         }

--- a/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/AIInOut.java
+++ b/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/AIInOut.java
@@ -130,7 +130,7 @@ public interface AIInOut {
 
         @Override
         public String toString() {
-            return "AIFileInOut [file=" + file + "]";
+            return file.toString();
         }
     }
 
@@ -183,7 +183,7 @@ public interface AIInOut {
 
         @Override
         public String toString() {
-            return "AIFileSegmentInOut [segmentedFile=" + segmentedFile + ", segmentIndex=" + segmentIndex + "]";
+            return segmentedFile.getFile() + " segment " + segmentIndex;
         }
     }
 

--- a/aigenpipeline-framework/src/test/java/net/stoerr/ai/aigenpipeline/framework/task/AIGenerationTaskTest.java
+++ b/aigenpipeline-framework/src/test/java/net/stoerr/ai/aigenpipeline/framework/task/AIGenerationTaskTest.java
@@ -138,4 +138,32 @@ public class AIGenerationTaskTest {
         checkOutputExistsAndIsAsExpected(outFile);
     }
 
+
+    @Test
+    public void testUnclutter() {
+        AIGenerationTask task = new AIGenerationTask();
+        String input = "<!--Copyright Adobe Licensed under--> // AIGenVersion(ourversion, inputfile1@version1, inputfile2@version2, ...)\n" +
+                "Some content";
+        String expected = " // \n" +
+                "Some content";
+        String result = task.unclutter(input);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testUnclutterInfilePrompting() {
+        AIGenerationTask task = new AIGenerationTask();
+        String input = "foo\n" +
+                "<!-- AIGenPromptStart(tablefromdatacopied)\n" +
+                "Make a markdown table from the data, with columns \"Name\" and \"Profession\".\n" +
+                "AIGenCommand(tablefromdatacopied)\n" +
+                "-f -m copy tablefromdata.md\n" +
+                "AIGenPromptEnd(tablefromdatacopied) -->\n" +
+                "bar";
+        String expected = "foo\n" +
+                "bar";
+        String result = task.unclutter(input);
+        assertEquals(expected, result);
+    }
+
 }

--- a/examples/infileprompt/copydata.md
+++ b/examples/infileprompt/copydata.md
@@ -23,7 +23,7 @@ AIGenPromptEnd(openaijson) -->
   "messages": [
     {
       "role": "system",
-      "content": "You are an expert programming assistant who follows the users instructions exactly and to the letter.\nYou observe the rules of clean code, KISS, YAGNI, and DRY and love good documentation and well documented code.\nDo never ever give any introductory or concluding text, just the requested output, except if explicitly asked for.\n\nIMPORTANT: If something in the instructions is unclear, there is information missing, you have any questions\nor after printing the response you notice that something was wrong, then append to the file a paragraph starting with\n`FIXME(GenAIPipeline) ` and a description of that problem.\n"
+      "content": "You are an expert programming assistant who follows the users instructions exactly and to the letter.\nYou observe the rules of clean code, KISS, YAGNI, and DRY and love good documentation and well documented code.\nDo never ever give any introductory or concluding text, just the requested output, except if explicitly asked for.\n\nIMPORTANT: If something in the instructions is unclear, there is information missing, you have any questions\nor after printing the response you notice that something was wrong, then append to the file a paragraph starting with\n`FIXME  ` and a description of that problem.\n"
     },
     {
       "role": "user",
@@ -35,7 +35,7 @@ AIGenPromptEnd(openaijson) -->
     },
     {
       "role": "user",
-      "content": "This uses the copy fake model to just copy the data.txt file. \n"
+      "content": "This uses the openaijson fake model to just insert the JSON that would have been sent to OpenAI into the file. \n"
     }
   ],
   "temperature": 0.0,

--- a/examples/infileprompt/tablefromdatacopied.md
+++ b/examples/infileprompt/tablefromdatacopied.md
@@ -4,3 +4,17 @@ Make a markdown table from the data, with columns "Name" and "Profession".
 AIGenCommand(tablefromdatacopied)
 -f -m copy tablefromdata.md
 AIGenPromptEnd(tablefromdatacopied) -->
+---
+version: AIGenVersion(22be7166, tablefromdatacopied.md-4b2aeec1, tablefromdata.md-75a7c09f)
+---
+
+Start of the file
+---
+version: 
+---
+
+| Name  | Profession         |
+|-------|--------------------|
+| Franz | Frontend developer |
+| Karl  | Backend developer  |
+| Maria | Designer           |

--- a/examples/infileprompt/tablefromdatacopied.md
+++ b/examples/infileprompt/tablefromdatacopied.md
@@ -1,0 +1,6 @@
+Start of the file tablefromdatacopied
+<!-- AIGenPromptStart(tablefromdatacopied)
+Make a markdown table from the data, with columns "Name" and "Profession".
+AIGenCommand(tablefromdatacopied)
+-f -m copy tablefromdata.md
+AIGenPromptEnd(tablefromdatacopied) -->


### PR DESCRIPTION
New option:

      -dd, --dependencydiagram Print a dependency diagram (Mermaid graph) of the scanned files and exit.

Displayable e.g. with https://mermaid.live/edit or mermaid or as mermaid diagram in a markdown file.

Also the execution of the found tasks is now ordered by their dependence if there is one.