### PR TITLE
Add version files for version markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Options:
     -go, --gen-older         Generate the output file if it does not exist or is older than any of the input files.
     -gv, --gen-versioncheck  Generate the output file if the version of the input files has changed. (Default.)
     -wv, --write-version     Write the output file with a version comment. (Default.)
+    -wvf, --write-versionfile Write the version comment to a separate file named like the output file with .version appended.
     -wo, --write-noversion   Write the output file without a version comment. Not compatible with default -gv .
     -wp, --write-part <marker> Replace the lines between the first occurrence of the marker and the second occurrence.
                              If a version marker is written, it has to be in the first of those lines and is changed there.

--- a/aigenpipeline-commandline/src/main/java/net/stoerr/ai/aigenpipeline/commandline/AIGenPipeline.java
+++ b/aigenpipeline-commandline/src/main/java/net/stoerr/ai/aigenpipeline/commandline/AIGenPipeline.java
@@ -489,6 +489,10 @@ public class AIGenPipeline {
                 case "--write-version":
                     writingStrategy = WritingStrategy.WITHVERSION;
                     break;
+                case "-wvf":
+                case "--write-versionfile":
+                    writingStrategy = WritingStrategy.WITHVERSIONFILE;
+                    break;
                 case "-wo":
                 case "--write-noversion":
                     writingStrategy = WritingStrategy.WITHOUTVERSION;

--- a/aigenpipeline-commandline/src/main/resources/aigencmdline/usage.txt
+++ b/aigenpipeline-commandline/src/main/resources/aigencmdline/usage.txt
@@ -43,6 +43,7 @@ Options:
     -go, --gen-older         Generate the output file if it does not exist or is older than any of the input files.
     -gv, --gen-versioncheck  Generate the output file if the version of the input files has changed. (Default.)
     -wv, --write-version     Write the output file with a version comment. (Default.)
+    -wvf, --write-versionfile Write the version comment to a separate file named like the output file with .version appended.
     -wo, --write-noversion   Write the output file without a version comment. Not compatible with default -gv .
     -wp, --write-part <marker> Replace the lines between the first occurrence of the marker and the second occurrence.
                              If a version marker is written, it has to be in the first of those lines and is changed there.

--- a/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/AIVersionMarker.java
+++ b/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/AIVersionMarker.java
@@ -2,7 +2,7 @@ package net.stoerr.ai.aigenpipeline.framework.task;
 
 import static java.util.Objects.requireNonNull;
 
-import java.io.IOException;
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -24,6 +24,13 @@ import javax.annotation.Nullable;
 public class AIVersionMarker {
 
     public static final Pattern VERSION_MARKER_PATTERN = Pattern.compile("AIGenVersion\\([^)]+\\)");
+
+    /**
+     * Suffix appended to files with formats braindead enough to not allow comments so that we have to store
+     * the file version in an additional file.
+     */
+    public static final String FILESUFFIX_VERSION = ".version";
+
     protected final String ourVersion;
     protected final List<String> inputVersions;
 
@@ -71,6 +78,13 @@ public class AIVersionMarker {
         String content = inOut.read();
         requireNonNull(content, "Could not read file " + inOut);
         AIVersionMarker aiVersionMarker = AIVersionMarker.find(content);
+        if (aiVersionMarker == null) {
+            File versionFile = new File(inOut.getFile() + FILESUFFIX_VERSION);
+            if (versionFile.exists()) {
+                String versionFileContent = AIInOut.of(versionFile).read();
+                aiVersionMarker = AIVersionMarker.find(versionFileContent);
+            }
+        }
         String version;
         if (aiVersionMarker != null) {
             version = aiVersionMarker.getOurVersion();

--- a/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/WritingStrategy.java
+++ b/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/WritingStrategy.java
@@ -1,5 +1,7 @@
 package net.stoerr.ai.aigenpipeline.framework.task;
 
+import static net.stoerr.ai.aigenpipeline.framework.task.AIVersionMarker.FILESUFFIX_VERSION;
+
 import java.io.File;
 
 import javax.annotation.Nonnull;
@@ -54,19 +56,18 @@ public interface WritingStrategy {
             } catch (RuntimeException e) {
                 return null;
             }
-            if (content == null) {
-                File versionFile = new File(output.getFile() + ".version");
+            AIVersionMarker aiVersionMarker = AIVersionMarker.find(content);
+            if (aiVersionMarker == null) {
+                File versionFile = new File(output.getFile() + FILESUFFIX_VERSION);
                 if (!versionFile.exists()) {
                     return null;
                 }
                 content = AIInOut.of(versionFile).read();
-                AIVersionMarker aiVersionMarker = AIVersionMarker.find(content);
+                aiVersionMarker = AIVersionMarker.find(content);
                 if (aiVersionMarker == null) { // here is really something wrong.
                     throw new IllegalStateException("Could not find version marker in " + versionFile);
                 }
-                return aiVersionMarker;
             }
-            AIVersionMarker aiVersionMarker = AIVersionMarker.find(content);
             /* if (aiVersionMarker == null) {
                 throw new IllegalStateException("Could not find version marker in " + output);
             } probably invalid heuristic. */
@@ -120,7 +121,7 @@ public interface WritingStrategy {
         @Override
         public void write(@Nonnull AIInOut output, @Nonnull String content, @Nonnull String versionComment) {
             output.write(content);
-            File versionFile = new File(output.getFile() + ".version");
+            File versionFile = new File(output.getFile() + FILESUFFIX_VERSION);
             AIInOut.of(versionFile).write(versionComment);
         }
 

--- a/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/WritingStrategy.java
+++ b/aigenpipeline-framework/src/main/java/net/stoerr/ai/aigenpipeline/framework/task/WritingStrategy.java
@@ -1,6 +1,6 @@
 package net.stoerr.ai.aigenpipeline.framework.task;
 
-import java.io.IOException;
+import java.io.File;
 
 import javax.annotation.Nonnull;
 
@@ -21,7 +21,7 @@ public interface WritingStrategy {
      */
     WritingStrategy WITHOUTVERSION = new WritingStrategy() {
         @Override
-        public void write(@Nonnull AIInOut output, @Nonnull String content, @Nonnull String versionComment)  {
+        public void write(@Nonnull AIInOut output, @Nonnull String content, @Nonnull String versionComment) {
             output.write(content);
         }
 
@@ -42,7 +42,7 @@ public interface WritingStrategy {
      */
     WritingStrategy WITHVERSION = new WritingStrategy() {
         @Override
-        public void write(@Nonnull AIInOut output, @Nonnull String content, @Nonnull String versionComment)  {
+        public void write(@Nonnull AIInOut output, @Nonnull String content, @Nonnull String versionComment) {
             output.write(embedComment(output, content, versionComment));
         }
 
@@ -55,7 +55,16 @@ public interface WritingStrategy {
                 return null;
             }
             if (content == null) {
-                return null;
+                File versionFile = new File(output.getFile() + ".version");
+                if (!versionFile.exists()) {
+                    return null;
+                }
+                content = AIInOut.of(versionFile).read();
+                AIVersionMarker aiVersionMarker = AIVersionMarker.find(content);
+                if (aiVersionMarker == null) { // here is really something wrong.
+                    throw new IllegalStateException("Could not find version marker in " + versionFile);
+                }
+                return aiVersionMarker;
             }
             AIVersionMarker aiVersionMarker = AIVersionMarker.find(content);
             /* if (aiVersionMarker == null) {
@@ -101,6 +110,28 @@ public interface WritingStrategy {
         @Override
         public String toString() {
             return "WritingStrategy.WITHVERSION";
+        }
+    };
+
+    /**
+     * Writes an additional file (.version) with the version.
+     */
+    WritingStrategy WITHVERSIONFILE = new WritingStrategy() {
+        @Override
+        public void write(@Nonnull AIInOut output, @Nonnull String content, @Nonnull String versionComment) {
+            output.write(content);
+            File versionFile = new File(output.getFile() + ".version");
+            AIInOut.of(versionFile).write(versionComment);
+        }
+
+        @Override
+        public AIVersionMarker getRecordedVersionMarker(@Nonnull AIInOut output) {
+            return WITHVERSION.getRecordedVersionMarker(output);
+        }
+
+        @Override
+        public String toString() {
+            return "WritingStrategy.WITHVERSIONFILE";
         }
     };
 

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -264,6 +264,7 @@ Options:
     -go, --gen-older         Generate the output file if it does not exist or is older than any of the input files.
     -gv, --gen-versioncheck  Generate the output file if the version of the input files has changed. (Default.)
     -wv, --write-version     Write the output file with a version comment. (Default.)
+    -wvf, --write-versionfile Write the version comment to a separate file named like the output file with .version appended.
     -wo, --write-noversion   Write the output file without a version comment. Not compatible with default -gv .
     -wp, --write-part <marker> Replace the lines between the first occurrence of the marker and the second occurrence.
                              If a version marker is written, it has to be in the first of those lines and is changed there.


### PR DESCRIPTION
Since some file formats (e.g. JSON) are braindead enough that they don't allow comments, we add a strategy -wvf to write a .version file: the version for foo.json is read and written from / to foo.json.version .